### PR TITLE
fix(ui): make @karmada/utils compatible with TypeScript 6 CI

### DIFF
--- a/ui/packages/utils/tsconfig.json
+++ b/ui/packages/utils/tsconfig.json
@@ -3,7 +3,9 @@
     "target": "ES2020",
     "useDefineForClassFields": true,
     "lib": ["ES2020", "DOM", "DOM.Iterable"],
+    "types": ["node"],
     "module": "ESNext",
+    "ignoreDeprecations": "5.0",
     "skipLibCheck": true,
 
     /* Bundler mode */


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

TypeScript 6 made the frontend CI fail in `@karmada/utils` during type generation. The package tsconfig did not include Node builtin types, so `path`, `fs`, and `url` were unresolved, and TS6 treated deprecation warnings as blocking without an explicit suppression baseline.

This change updates `ui/packages/utils/tsconfig.json` to add `types: ["node"]` and `ignoreDeprecations: "5.0"`, which keeps the package build compatible with TS5 and TS6 and unblocks `build-frontend` and `e2e-frontend` jobs.

**Which issue(s) this PR fixes**:
N/A

**Special notes for your reviewer**:

This is a focused CI compatibility fix for the dependabot TS6 bump path and only changes `@karmada/utils` compiler options.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```